### PR TITLE
Add support for .twig files

### DIFF
--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: ExtensionContext) {
     };
 
     let clientOptions: LanguageClientOptions = {
-        documentSelector: ['html', 'htm'],
+        documentSelector: ['html', 'htm', 'twig'],
         synchronize: {
             configurationSection: 'htmlhint',
             fileEvents: workspace.createFileSystemWatcher('**/.htmlhintrc')


### PR DESCRIPTION
Twig template language doesn't use angle brackets (unlike ERB and some others), so there shouldn't be any conflicts with supporting Twig files by default. This allows users to lint the HTML parts of Twig files while still using other extensions for better Twig syntax highlighting, text expansion, etc.