### PR TITLE
Add support for user defined file extensions

### DIFF
--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -49,16 +49,23 @@ You can learn more about rule configuration at the HTMLHint [Usage page](https:/
 
 ## Settings
 
-The HTMLHint extension provides two [settings](https://code.visualstudio.com/docs/customization/userandworkspace):
+The HTMLHint extension provides three [settings](https://code.visualstudio.com/docs/customization/userandworkspace):
 
 * `htmlhint.enable` - disable the HTMLHint extension globally or per workspace.
+* `htmlhint.extensions` - specify additional file extensions to be linted
 * `htmlhint.options` - provide a rule set to override on disk `.htmlhintrc` or HTMLHint defaults.
 
 You can change settings globally (**File** > **Preferences** > **User Settings**) or per workspace (**File** > **Preferences** > **Workspace Settings**). The **Preferences** menu is under **Code** on macOS.
 
-Here's an example using the `htmlhint.options` setting:
+Here's an example using the `htmlhint.extensions` and `htmlhint.options` settings:
 
 ```json
+"htmlhint.extensions: [
+    "html",
+    "htm",
+    "twig",
+    "mustache"
+],
 "htmlhint.options": {
     "tagname-lowercase": false,
     "attr-lowercase": true,

--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -13,8 +13,13 @@ export function activate(context: ExtensionContext) {
         debug: { module: serverModulePath, options: debugOptions }
     };
 
+    // Get file types to lint from user settings
+    let config = workspace.getConfiguration('htmlhint');
+    let extensions = config.get('extensions');
+    
+    // Set options
     let clientOptions: LanguageClientOptions = {
-        documentSelector: ['html', 'htm'],
+        documentSelector: extensions,
         synchronize: {
             configurationSection: 'htmlhint',
             fileEvents: workspace.createFileSystemWatcher('**/.htmlhintrc')

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -42,7 +42,7 @@
         },
         "htmlhint.extensions": {
           "type": "array",
-          "default": ["html", "html"],
+          "default": ["html", "htm"],
           "description": "The file extensions to be linted."
         },
         "htmlhint.options": {

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -40,6 +40,11 @@
           "default": true,
           "description": "Control whether htmlhint is enabled for HTML files or not."
         },
+        "htmlhint.extensions": {
+          "type": "array",
+          "default": ["html", "html"],
+          "description": "The file extensions to be linted."
+        },
         "htmlhint.options": {
           "type": "object",
           "default": {},


### PR DESCRIPTION
Create new configuration object (`extensions`) and replace hard-coded array for `documentSelector` with the user-defined `extensions` array. Defaults are still "html" and "htm".