### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -15,11 +15,12 @@ export function activate(context: ExtensionContext) {
 
     // Get file types to lint from user settings
     let config = workspace.getConfiguration('htmlhint');
-    let extensions = config.get('documentSelector') as string[];
+    let languages: string[] = config.get('documentSelector');
+    let documentSelector = languages.map(language => ({ language, scheme: 'file' }));
 
     // Set options
     let clientOptions: LanguageClientOptions = {
-        documentSelector: extensions,
+        documentSelector,
         synchronize: {
             configurationSection: 'htmlhint',
             fileEvents: workspace.createFileSystemWatcher('**/.htmlhintrc')


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for HTML, this PR simply updates the current `DocumentSelector` to be limited to local files. This way, when someone has the HTMLHint extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*