### PR TITLE
Add rules directory configuration

### DIFF
--- a/htmlhint-server/package.json
+++ b/htmlhint-server/package.json
@@ -10,7 +10,8 @@
     "fs": "0.0.2",
     "htmlhint": "^0.9.13",
     "strip-json-comments": "^2.0.0",
-    "vscode-languageserver": "^3.4.0"
+    "vscode-languageserver": "^3.4.0",
+    "glob": "5.0.15"
   },
   "devDependencies": {
     "@types/node": "^6.0.41",

--- a/htmlhint-server/package.json
+++ b/htmlhint-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmlhint-server",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "HtmlHint Linter Server",
   "engines": {
     "node": "*"

--- a/htmlhint-server/src/typings-custom/htmlhint.d.ts
+++ b/htmlhint-server/src/typings-custom/htmlhint.d.ts
@@ -5,6 +5,7 @@ declare module 'htmlhint' {
 
     export interface Verifier {
         verify(text: string): Error[];
+        loadCustomRules(rulesdir: string): any;
     }
 
     export interface Error {

--- a/htmlhint/README.md
+++ b/htmlhint/README.md
@@ -78,11 +78,12 @@ If your file type already has an associated language service other than "html", 
 
 ## Settings
 
-The HTMLHint extension provides three [settings](https://code.visualstudio.com/docs/customization/userandworkspace):
+The HTMLHint extension provides four [settings](https://code.visualstudio.com/docs/customization/userandworkspace):
 
 * `htmlhint.enable` - disable the HTMLHint extension globally or per workspace.
 * `htmlhint.documentSelector` - specify additional language services to be linted
 * `htmlhint.options` - provide a rule set to override on disk `.htmlhintrc` or HTMLHint defaults.
+* `htmlhint.rulesDir` - provide an absolute or relative path to a folder containing custom rules.
 
 You can change settings globally (**File** > **Preferences** > **User Settings**) or per workspace (**File** > **Preferences** > **Workspace Settings**). The **Preferences** menu is under **Code** on macOS.
 

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "HTMLHint.png",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "mkaufman",
   "galleryBanner": {
     "color": "#0000FF",
@@ -39,6 +39,11 @@
           "type": "boolean",
           "default": true,
           "description": "Control whether htmlhint is enabled for HTML files or not."
+        },
+        "htmlhint.rulesDir": {
+          "type": "string",
+          "default": "",
+          "description": "Folder containing custom rules, absolute or relative to workspace root."
         },
         "htmlhint.documentSelector": {
           "type": "array",

--- a/htmlhint/package.json
+++ b/htmlhint/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTMLHint",
   "description": "VS Code integration for HTMLHint - A Static Code Analysis Tool for HTML",
   "icon": "HTMLHint.png",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "publisher": "mkaufman",
   "galleryBanner": {
     "color": "#0000FF",


### PR DESCRIPTION
We use custom html hinting rules, this is a small improvement to allow you to specify the folder containing those rules.