### PR TITLE
Fall back to default configuratiuon file.

### DIFF
--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -93,6 +93,8 @@ function getConfiguration(filePath: string): any {
             }
         } else if (settings.htmlhint.options && Object.keys(settings.htmlhint.options).length > 0) {
             options = settings.htmlhint.options;
+        } else {
+            options = findConfigForHtmlFile(filePath);
         }
     } else {
         options = findConfigForHtmlFile(filePath);


### PR DESCRIPTION
We might have configuration settings without options or configFile elements.
In this case we should still look for the default configuration file.
This should fix  https://github.com/microsoft/vscode-htmlhint/issues/74