### PR TITLE
Fix for error: Header must provide a Content-Length property

### DIFF
--- a/htmlhint-server/src/server.ts
+++ b/htmlhint-server/src/server.ts
@@ -183,7 +183,7 @@ function validateTextDocument(connection: server.IConnection, document: server.T
     }
 }
 
-let connection: server.IConnection = server.createConnection(process.stdin, process.stdout);
+let connection: server.IConnection = server.createConnection();
 let documents: server.TextDocuments = new server.TextDocuments();
 documents.listen(connection);
 

--- a/htmlhint/extension.ts
+++ b/htmlhint/extension.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { workspace, Disposable, ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind } from 'vscode-languageclient';
 
 export function activate(context: ExtensionContext) {
 
@@ -9,8 +9,8 @@ export function activate(context: ExtensionContext) {
     let serverModulePath = path.join(__dirname, '..', 'server', 'server.js');
     let debugOptions = { execArgv: ["--nolazy", "--inspect=6010"], cwd: process.cwd() };
     let serverOptions: ServerOptions = {
-        run: { module: serverModulePath },
-        debug: { module: serverModulePath, options: debugOptions }
+        run: { module: serverModulePath, transport: TransportKind.ipc },
+        debug: { module: serverModulePath, transport: TransportKind.ipc, options: debugOptions }
     };
 
     // Get file types to lint from user settings


### PR DESCRIPTION
Fixes #80

HTMLHint uses stdin/stdout to talk to the language server. Since a few releases, the node version we use in VSCode emits
` [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead`
interfering with the LS messages and causing the LS initialization to fail.

The simplest fix is to switch to use IPC.

The LS version used is quite old.
@mike-kaufman If you're interested I can add a commit to update to the latest version.
I believe the latest version of the LS also no longer references Buffer().